### PR TITLE
Fixing Artifacts generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,3 @@
-
 name: Build
 
 on:
@@ -7,28 +6,39 @@ on:
   pull_request:
     branches: [ "main" ]
     
-env:
-  # This is the only line that has to be changed on a per-project basis
-  MOD_NAME: "Debug Mod"
-
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
+    
     - name: Setup
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
+        
     - name: Restore
       run: dotnet restore
+      
     - name: Build
       run: dotnet build --configuration Release --no-restore
+      
+    - name: Extract Module Name and Version
+      id: extract_info
+      run: |
+        CS_PROJ_PATH=$(find . -type f -name "*.csproj")
+        MOD_NAME=$(grep -oP '<TargetName>\K[^<]+' "$CS_PROJ_PATH")
+        MOD_VERSION=$(grep -oP '<Version>\K[^<]+' "$CS_PROJ_PATH")
+        echo "MOD_NAME=$MOD_NAME" >> $GITHUB_ENV
+        echo "MOD_VERSION=$MOD_VERSION" >> $GITHUB_ENV
+        BUILD_DATE=$(date +'%Y-%m-%d')
+        echo "BUILD_DATE=$BUILD_DATE" >> $GITHUB_ENV
+        
     - name: Upload
       uses: actions/upload-artifact@v3
       with:
-        name: ${{env.MOD_NAME}}
-        path: publish/${{env.MOD_NAME}}/
-        retention-days: 20
+        name: ${{ env.MOD_NAME }} v${{ env.MOD_VERSION }} ${{ env.BUILD_DATE }}
+        path: publish/${{ env.MOD_NAME }}/
+        retention-days: 30
+        if-no-files-found: error


### PR DESCRIPTION
Artifacts weren't generated due to a spelling error in MOD_NAME.

- MOD_NAME didn't correspond with the project name.
- I've included a version number with the build date, which can help us distinguish when each build was created (just a suggestion)